### PR TITLE
Add dev compose override

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Este proyecto implementa un asistente virtual para cualquier facultad de la UBA 
 ├── logs/                   # Archivos de registro
 ├── docs/                   # Documentación del proyecto
 ├── Dockerfile              # Configuración para Docker
-└── docker-compose.yml      # Configuración de servicios Docker
+├── docker-compose.yml      # Configuración del servicio (producción)
+└── docker-compose.override.yml # Montajes de desarrollo
 ```
 
 ## Configuración
@@ -184,7 +185,8 @@ El proyecto está configurado para ser desplegado usando Docker, separando el pr
 ```
 .
 ├── Dockerfile           # Configuración de la imagen
-├── docker-compose.yml   # Configuración del servicio
+├── docker-compose.yml   # Configuración del servicio (producción)
+├── docker-compose.override.yml # Montajes de desarrollo
 └── .dockerignore        # Archivos excluidos del contenedor
 ```
 
@@ -215,6 +217,7 @@ docker-compose build
 ```bash
 docker-compose up -d
 ```
+Esto cargará automáticamente `docker-compose.override.yml` en desarrollo para montar los volúmenes necesarios.
 
 3. **Ver logs:**
 ```bash

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+
+services:
+  chatbot:
+    volumes:
+      - ./data/embeddings:/app/data/embeddings
+      - ./scripts:/app/scripts
+      - ./config:/app/config
+      - ./models:/app/models
+      - ./storage:/app/storage
+      - ./utils:/app/utils
+      - ./handlers:/app/handlers
+      - ./services:/app/services
+      - ./rag_system.py:/app/rag_system.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,16 +14,6 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - CURSOS_SPREADSHEET_ID=${CURSOS_SPREADSHEET_ID}
       - GOOGLE_API_KEY=${GOOGLE_API_KEY}
-    volumes:
-      - ./data/embeddings:/app/data/embeddings
-      - ./scripts:/app/scripts
-      - ./config:/app/config
-      - ./models:/app/models
-      - ./storage:/app/storage
-      - ./utils:/app/utils
-      - ./handlers:/app/handlers
-      - ./services:/app/services
-      - ./rag_system.py:/app/rag_system.py
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]


### PR DESCRIPTION
## Summary
- keep production `docker-compose.yml` free from host mounts
- create `docker-compose.override.yml` with development volumes
- document new override file in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687414331d648329ab0d12deb2f00a84