### PR TITLE
Clean imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ API_TIMEOUT=30                                   # Timeout para llamadas a APIs 
 ### Desarrollo Local
 1. **Procesamiento de Documentos:**
 ```bash
-python scripts/preprocess.py
+python -m scripts.preprocess
 ```
 Este script:
 - Procesa los PDFs en `data/raw/`
@@ -161,7 +161,7 @@ Este script:
 
 2. **Generación de Embeddings:**
 ```bash
-python scripts/create_embeddings.py
+python -m scripts.create_embeddings
 ```
 Este script:
 - Genera embeddings usando OpenAI
@@ -174,6 +174,11 @@ Para desarrollo puedes exponer tu servidor con ngrok o seguir las instrucciones 
 3. **Ejecución Local:**
 ```bash
 uvicorn main:app --reload
+```
+
+4. **Probar el sistema RAG por consola:**
+```bash
+python -m scripts.run_rag
 ```
 
 ### Despliegue con Docker
@@ -255,8 +260,8 @@ docker run -p 8000:8000 \
 1. Añadir nuevos PDFs en `data/raw/`
 2. Ejecutar localmente el preprocesamiento:
    ```bash
-   python scripts/preprocess.py
-   python scripts/create_embeddings.py
+   python -m scripts.preprocess
+   python -m scripts.create_embeddings
    ```
 3. Los nuevos embeddings se generarán en `data/embeddings/`
 4. El contenedor Docker montará automáticamente los nuevos embeddings

--- a/scripts/run_rag.py
+++ b/scripts/run_rag.py
@@ -1,9 +1,3 @@
-import sys
-from pathlib import Path
-
-# Añadir el directorio raíz al path para acceder a rag_system.py
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 from rag_system import RAGSystem
 
 

--- a/services/calendar_service.py
+++ b/services/calendar_service.py
@@ -10,10 +10,6 @@ from typing import List, Dict, Optional
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 import pytz
-import sys
-
-# Añadir el directorio raíz al path de Python
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from config.calendar_config import CALENDAR_CONFIG, CALENDARS
 from utils.date_utils import DateUtils

--- a/services/sheets_service.py
+++ b/services/sheets_service.py
@@ -8,11 +8,7 @@ import logging
 from typing import List, Dict, Optional, Any
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
-import sys
 from datetime import datetime, timedelta
-
-# Añadir el directorio raíz al path de Python
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # Configurar logging
 logging.basicConfig(level=logging.INFO)

--- a/test/test_normativas.py
+++ b/test/test_normativas.py
@@ -1,9 +1,5 @@
 import os
-import sys
 from dotenv import load_dotenv
-
-# Añadir el directorio raíz al path para poder importar rag_system
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from rag_system import RAGSystem
 
 """


### PR DESCRIPTION
## Summary
- remove sys.path tweaks in services and scripts
- document running scripts as modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687417daa3748329b2b32bdcfe7a53bd