### PR TITLE
Remove outdated train_finetune reference

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -51,4 +51,4 @@ notebooks/
 # Scripts de preprocesamiento (no necesarios en producción)
 scripts/preprocess.py
 scripts/create_embeddings.py
-scripts/train_finetune.py 
+


### PR DESCRIPTION
## Summary
- remove `scripts/train_finetune.py` from `.dockerignore`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68741a35f5388329ac81cb436def1ea6