### PR TITLE
Secure webhook validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,10 @@ Esta adaptación está implementada en el módulo `scripts/gcs_storage.py`, que 
    gcloud logging read "resource.type=cloud_run_revision AND resource.labels.service_name=[SERVICE_NAME]" --limit=50
    ```
 
+5. **Seguridad del webhook**: En entorno de producción se valida la cabecera `X-Hub-Signature-256` usando el token configurado en `WHATSAPP_WEBHOOK_VERIFY_TOKEN`. Esta firma garantiza que los mensajes provienen de WhatsApp Business.
+
+6. **CORS deshabilitado**: Como la API no se consume desde navegadores, se eliminó el middleware de CORS para reducir la superficie de ataque.
+
 ### Monitoreo y Mantenimiento
 
 - Los logs se encuentran en la carpeta `logs/`

--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ import json
 import requests
 from typing import Dict, Any
 from fastapi import FastAPI, HTTPException, Request, Response
-from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
 from rag_system import RAGSystem
 from handlers.whatsapp_handler import WhatsAppHandler
@@ -63,14 +62,6 @@ app = FastAPI(
     version="1.0.0"
 )
 
-# Configurar CORS
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
 
 # Middleware para manejo directo de WebHooks de WhatsApp en producción
 if ENVIRONMENT == "production":
@@ -155,26 +146,26 @@ async def whatsapp_webhook(request: Request):
         # Obtener el cuerpo de la solicitud
         body = await request.body()
         
-        # COMENTADO TEMPORALMENTE: Validar la firma del webhook en producción
-        # if ENVIRONMENT == "production":
-        #     signature = request.headers.get("x-hub-signature-256", "")
-        #     if not signature:
-        #         logger.error("Firma no encontrada en headers")
-        #         raise HTTPException(status_code=403, detail="Firma no encontrada")
-                
-        #     # Calcular y verificar firma
-        #     import hmac
-        #     import hashlib
-            
-        #     expected_signature = hmac.new(
-        #         WHATSAPP_WEBHOOK_VERIFY_TOKEN.encode(),
-        #         body,
-        #         hashlib.sha256
-        #     ).hexdigest()
-            
-        #     if not hmac.compare_digest(f"sha256={expected_signature}", signature):
-        #         logger.error("Firma inválida")
-        #         raise HTTPException(status_code=403, detail="Firma inválida")
+        # Validar la firma del webhook en producción
+        if ENVIRONMENT == "production":
+            signature = request.headers.get("x-hub-signature-256", "")
+            if not signature:
+                logger.error("Firma no encontrada en headers")
+                raise HTTPException(status_code=403, detail="Firma no encontrada")
+
+            # Calcular y verificar firma
+            import hmac
+            import hashlib
+
+            expected_signature = hmac.new(
+                WHATSAPP_WEBHOOK_VERIFY_TOKEN.encode(),
+                body,
+                hashlib.sha256
+            ).hexdigest()
+
+            if not hmac.compare_digest(f"sha256={expected_signature}", signature):
+                logger.error("Firma inválida")
+                raise HTTPException(status_code=403, detail="Firma inválida")
         
         # Parsear el cuerpo JSON
         try:


### PR DESCRIPTION
## Summary
- remove open CORS middleware
- activate HMAC signature check for WhatsApp webhook
- document webhook security and CORS removal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687420e2296483298d9826424336290b